### PR TITLE
RR-197 Fix mem leak

### DIFF
--- a/src/logreqres.c
+++ b/src/logreqres.c
@@ -205,6 +205,8 @@ size_t reqresAppendResponse(client *c) {
     if (listLength(c->reply)) {
         curr_index = listLength(c->reply) - 1;
         curr_used = ((clientReplyBlock *)listNodeValue(listLast(c->reply)))->used;
+    } else {
+        goto release_buf;
     }
 
     /* Now, append reply bytes from the reply list */
@@ -255,6 +257,7 @@ size_t reqresAppendResponse(client *c) {
     fflush(fp);
     fclose(fp);
 
+release_buf:
     zfree(c->reqres.buf);
     c->reqres.buf = NULL;
     c->reqres.used = c->reqres.capacity = 0;

--- a/src/networking.c
+++ b/src/networking.c
@@ -1537,6 +1537,8 @@ void clearClientConnectionState(client *c) {
 void freeClient(client *c) {
     listNode *ln;
 
+    reqresAppendResponse(c);
+
     /* If a client is protected, yet we need to free it right now, make sure
      * to at least use asynchronous freeing. */
     if (c->flags & CLIENT_PROTECTED) {


### PR DESCRIPTION
Free allocated req/res buffer while closing client connection.

This change will fix a mem leak found in "Regression for bug 593 - chaining BRPOPLPUSH with other blocking cmds" test, in type/list unit (closing connection to blocked client)